### PR TITLE
chore(ci): パーミッション設定を上位レベルからジョブ単位に移動

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,4 @@
 name: Deploy
-permissions:
-  contents: read
-  pull-requests: write
 
 on:
   push:
@@ -11,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +54,11 @@ jobs:
           path: ./dist
 
   deploy:
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
- 不要なパーミッションをグローバルに付与しないよう、トップレベルの `permissions` ブロックを削除
- `test` ジョブ用に `permissions` を追加（contents: read, pull-requests: write）
- `deploy` ジョブ用に `permissions` を追加（contents: read, pull-requests: write, id-token: write, pages: write）
- 各ジョブが必要なパーミッションのみを付与するように変更