### PR TITLE
chore(deps): 依存関係を更新（vue 3.5.22→3.5.27、vite 7.1.10→7.3.1、@vitejs/plug…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "vue": "^3.5.22",
-    "bootstrap": "^5.3.8"
+    "bootstrap": "^5.3.8",
+    "vue": "^3.5.27"
   },
   "devDependencies": {
-    "vite": "^7.1.10",
-    "@vitejs/plugin-vue": "^6.0.1",
-    "vite-plugin-vue-devtools": "^8.0.3",
+    "@vitejs/plugin-vue": "^6.0.3",
+    "vite": "^7.3.1",
+    "vite-plugin-vue-devtools": "^8.0.5",
     "vitest": "^2.1.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,17 +12,17 @@ importers:
         specifier: ^5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
       vue:
-        specifier: ^3.5.22
+        specifier: ^3.5.27
         version: 3.5.27
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^6.0.1
+        specifier: ^6.0.3
         version: 6.0.3(vite@7.3.1)(vue@3.5.27)
       vite:
-        specifier: ^7.1.10
+        specifier: ^7.3.1
         version: 7.3.1
       vite-plugin-vue-devtools:
-        specifier: ^8.0.3
+        specifier: ^8.0.5
         version: 8.0.5(vite@7.3.1)(vue@3.5.27)
       vitest:
         specifier: ^2.1.9


### PR DESCRIPTION
…in-vue 6.0.1→6.0.3、vite-plugin-vue-devtools 8.0.3→8.0.5）

- package.json の dependencies/devDependencies を更新
- pnpm-lock.yaml を同期更新